### PR TITLE
LT-XXX Add Env var for topic subscriptions

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,11 +1,27 @@
 require 'rubygems'
 require 'bundler/setup'
+require 'routemaster/client'
 require 'routemaster/receiver'
 require 'dotenv'
 require 'sinatra'
 require 'pry'
 
 Dotenv.load!
+
+subscriptions = ENV.fetch('TOPIC_SUBSCRIPTIONS', '').split(',')
+if subscriptions.any?
+  routemaster = Routemaster::Client.new(
+    url: ENV.fetch('ROUTEMASTER_URL'),
+    uuid: ENV.fetch('ROUTEMASTER_UUID', 'demo'),
+  )
+
+  routemaster.subscribe(
+    topics: subscriptions,
+    callback: ENV.fetch('CALLBACK_URL'),
+    uuid: ENV.fetch('CLIENT_UUID', 'demo'),
+    max: 1
+  )
+end
 
 class Handler
   def on_events(events)

--- a/config.ru
+++ b/config.ru
@@ -18,8 +18,7 @@ if subscriptions.any?
   routemaster.subscribe(
     topics: subscriptions,
     callback: ENV.fetch('CALLBACK_URL'),
-    uuid: ENV.fetch('CLIENT_UUID', 'demo'),
-    max: 1
+    uuid: ENV.fetch('CLIENT_UUID', 'demo')
   )
 end
 


### PR DESCRIPTION
Adds in an ENV var for subscribing to topics - make it easier to manage the events we want to watch and stops two bits of event sending QA from interfering with each-others topics.