### PR TITLE
SRE-539: update sinatra gem version for security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby(File.read(File.expand_path('../.ruby-version', __FILE__)).chomp)
 
 gem 'foreman'
 gem 'unicorn'
-gem 'sinatra'
+gem 'sinatra', '~> 2.0.1'
 gem 'pry'
 gem 'pry-nav'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     minitest (5.11.3)
     moneta (1.0.0)
     multipart-post (2.0.0)
-    mustermann (1.0.1)
+    mustermann (1.0.2)
     newrelic_rpm (4.8.0.341)
     oj (2.18.5)
     pry (0.10.4)
@@ -46,7 +46,7 @@ GEM
       pry (>= 0.9.10, < 0.11.0)
     public_suffix (3.0.1)
     rack (2.0.4)
-    rack-protection (2.0.0)
+    rack-protection (2.0.1)
       rack
     raindrops (0.19.0)
     redis (4.0.1)
@@ -69,10 +69,10 @@ GEM
       redis-namespace
       typhoeus (~> 1.1)
       wisper (~> 1.6.1)
-    sinatra (2.0.0)
+    sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.1)
       tilt (~> 2.0)
     slop (3.6.0)
     thor (0.19.4)
@@ -101,7 +101,7 @@ DEPENDENCIES
   pry-nav
   routemaster-client
   routemaster-drain
-  sinatra
+  sinatra (~> 2.0.1)
   unicorn
 
 RUBY VERSION


### PR DESCRIPTION
closes [SRE-539](https://deliveroo.atlassian.net/browse/SRE-539)

![screenshot from 2018-05-18 09-32-56](https://user-images.githubusercontent.com/4441006/40224562-79e70234-5a7e-11e8-9ea3-2f2c3def4812.png)